### PR TITLE
Services by DayOfWeek, tenantId, origin y destination

### DIFF
--- a/bll/src/com/usbus/bll/administration/beans/ServiceBean.java
+++ b/bll/src/com/usbus/bll/administration/beans/ServiceBean.java
@@ -7,6 +7,7 @@ import com.usbus.dal.model.Service;
 import org.bson.types.ObjectId;
 
 import javax.ejb.Stateless;
+import java.time.DayOfWeek;
 import java.util.Date;
 import java.util.List;
 
@@ -36,6 +37,11 @@ public class ServiceBean implements ServiceLocal, ServiceRemote{
     @Override
     public List<Service> getServicesByTenantAndDate(long tenantId, Date time, int offset, int limit) {
         return dao.getServicesByTenantAndDate(tenantId, time, offset, limit);
+    }
+
+    @Override
+    public List<Service> getServicesByTenantDOWAndStops(long tenantId, DayOfWeek day, String origin, String destination, int offset, int limit) {
+        return dao.getServicesByTenantDOWAndStops(tenantId, day, origin, destination, offset, limit);
     }
 
     @Override

--- a/bll/src/com/usbus/bll/administration/interfaces/ServiceLocal.java
+++ b/bll/src/com/usbus/bll/administration/interfaces/ServiceLocal.java
@@ -4,6 +4,7 @@ import com.usbus.dal.model.Service;
 import org.bson.types.ObjectId;
 
 import javax.ejb.Local;
+import java.time.DayOfWeek;
 import java.util.Date;
 import java.util.List;
 
@@ -16,6 +17,7 @@ public interface ServiceLocal {
     Service getByLocalId(long tenantId, Long serviceId);
     ObjectId persist(Service service);
     List<Service> getServicesByTenantAndDate(long tenantId, Date time, int offset, int limit);
+    List<Service> getServicesByTenantDOWAndStops(long tenantId, DayOfWeek day, String origin, String destination, int offset, int limit);
     List<Service> getServicesByTenant(long tenantId, int offset, int limit);
     void setInactive(long tenantId, Long serviceId);
     void setActive(long tenantId, Long serviceId);

--- a/bll/src/com/usbus/bll/administration/interfaces/ServiceRemote.java
+++ b/bll/src/com/usbus/bll/administration/interfaces/ServiceRemote.java
@@ -4,6 +4,7 @@ import com.usbus.dal.model.Service;
 import org.bson.types.ObjectId;
 
 import javax.ejb.Remote;
+import java.time.DayOfWeek;
 import java.util.Date;
 import java.util.List;
 
@@ -17,6 +18,7 @@ public interface ServiceRemote {
     Service getByLocalId(long tenantId, Long serviceId);
     ObjectId persist(Service service);
     List<Service> getServicesByTenantAndDate(long tenantId, Date time, int offset, int limit);
+    List<Service> getServicesByTenantDOWAndStops(long tenantId, DayOfWeek day, String origin, String destination, int offset, int limit);
     List<Service> getServicesByTenant(long tenantId, int offset, int limit);
     void setInactive(long tenantId, Long serviceId);
     void setActive(long tenantId, Long serviceId);

--- a/dal/src/com/usbus/dal/dao/ServiceDAO.java
+++ b/dal/src/com/usbus/dal/dao/ServiceDAO.java
@@ -1,5 +1,6 @@
 package com.usbus.dal.dao;
 
+import com.usbus.commons.auxiliaryClasses.RouteStop;
 import com.usbus.dal.GenericPersistence;
 import com.usbus.dal.MongoDB;
 import com.usbus.dal.model.Service;
@@ -8,6 +9,8 @@ import org.mongodb.morphia.Datastore;
 import org.mongodb.morphia.query.Query;
 import org.mongodb.morphia.query.UpdateOperations;
 
+import java.time.DayOfWeek;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
@@ -45,6 +48,40 @@ public class ServiceDAO {
         query.and(query.criteria("time").equal(time),
                 query.criteria("tenantId").equal(tenantId));
         return query.offset(offset).limit(limit).asList();
+    }
+
+    public List<Service> getServicesByTenantDOWAndStops(long tenantId, DayOfWeek day, String origin, String destination, int offset, int limit){
+        if(!(tenantId > 0) ||
+                (day == null) ||
+                (offset < 0) || (limit <= 0) ||
+                origin == null || destination == null ||
+                origin.equals(destination)){
+            return null;
+        }
+        Query<Service> query = ds.createQuery(Service.class);
+        query.and(query.criteria("day").equal(day),
+                query.criteria("tenantId").equal(tenantId));
+        List<Service> resultList = query.offset(offset).limit(limit).asList();
+        List<Service> auxList = new ArrayList<>(resultList);
+        if(auxList.isEmpty()) {
+            return null;
+        } else {
+            int oriIdx = -1, dstIdx = -1;
+            for (Service srv : auxList) {
+                List<RouteStop> stops = srv.getRoute().getBusStops();
+                for (int i = 0; i < stops.size(); i++) {
+                    if (stops.get(i).getBusStop().equals(origin)) { //origin found in route
+                        oriIdx = i;
+                    } else if (stops.get(i).getBusStop().equals(destination)) { //destination found in route
+                        dstIdx = i;
+                    }
+                }
+                if(oriIdx < 0 || dstIdx < 0 || oriIdx >= dstIdx){ //check if both found in correct order
+                    resultList.remove(srv);
+                }
+            }
+        }
+        return resultList;
     }
 
     public List<Service> getServicesByTenant(long tenantId, int offset, int limit){

--- a/dal/test/com/usbus/dal/test/ServiceTest.java
+++ b/dal/test/com/usbus/dal/test/ServiceTest.java
@@ -1,6 +1,8 @@
 package com.usbus.dal.test;
 
 import com.usbus.commons.auxiliaryClasses.RouteStop;
+import com.usbus.dal.dao.BusStopDAO;
+import com.usbus.dal.dao.RouteDAO;
 import com.usbus.dal.dao.ServiceDAO;
 import com.usbus.dal.model.BusStop;
 import com.usbus.dal.model.Route;
@@ -19,6 +21,8 @@ import java.util.TimeZone;
  */
 public class ServiceTest {
     protected ServiceDAO dao = new ServiceDAO();
+    protected RouteDAO rdao = new RouteDAO();
+    protected BusStopDAO bsdao = new BusStopDAO();
 
     @Test
     public void persist() throws ParseException {
@@ -40,15 +44,18 @@ public class ServiceTest {
         dao.persist(srv);
 
         BusStop origin = new BusStop(2, 1L, "Montevideo", true, 10.0);
+        bsdao.persist(origin);
         BusStop destination = new BusStop(2, 2L, "Colonia", true, 10.0);
-        RouteStop rsOrigin = new RouteStop("Montevideo", 0.0, false);
+        bsdao.persist(destination);
+        RouteStop rsMvd = new RouteStop("Montevideo", 0.0, false);
         RouteStop rsPzaCuba = new RouteStop("Plaza Cuba", 7.4, false);
         RouteStop rsColonia = new RouteStop("Colonia", 176.5, false);
         List<RouteStop> routeStops = new ArrayList<>();
-        routeStops.add(rsOrigin);
+        routeStops.add(rsMvd);
         routeStops.add(rsPzaCuba);
         routeStops.add(rsColonia);
         Route route = new Route(2, 1L, "Montevideo - Colonia", origin, destination, routeStops, true, false, 2.30);
+        rdao.persist(route);
         srv = new Service(2, 5L, "Montevideo - Colonia (Común)", DayOfWeek.FRIDAY, format.parse("09:15"), route, 3, true);
         dao.persist(srv);
 

--- a/services/src/com/usbus/services/administration/ServiceService.java
+++ b/services/src/com/usbus/services/administration/ServiceService.java
@@ -9,6 +9,7 @@ import org.bson.types.ObjectId;
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import java.time.DayOfWeek;
 import java.util.Date;
 import java.util.List;
 
@@ -47,11 +48,11 @@ public class ServiceService {
     }
 
     @GET
-    @Path("{serviceId}")
+    @Path("id/{serviceId}")
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
     @Secured(Rol.ADMINISTRATOR)
-    public Response getService(@PathParam("tenantId")Long tenantId, @PathParam("serviceId") Long serviceId){
+    public Response getService(@PathParam("tenantId")long tenantId, @PathParam("serviceId") Long serviceId){
 
         Service serviceAux = ejb.getByLocalId(tenantId,serviceId);
         if (serviceAux == null){
@@ -61,6 +62,7 @@ public class ServiceService {
     }
 
     @GET
+    @Path("get/all")
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
     @Secured(Rol.ADMINISTRATOR)
@@ -74,6 +76,7 @@ public class ServiceService {
     }
 
     @GET
+    @Path("get/bydate")
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
     @Secured(Rol.ADMINISTRATOR)
@@ -81,6 +84,25 @@ public class ServiceService {
 
         List<Service> serviceList = ejb.getServicesByTenantAndDate(tenantId, time, offset, limit);
         if (serviceList == null){
+            return Response.status(Response.Status.NO_CONTENT).build();
+        }
+        return Response.ok(serviceList).build();
+    }
+
+    @GET
+    @Path("get/dowfromto")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Secured({Rol.ADMINISTRATOR, Rol.CLIENT})
+    public Response getServiceListByTenantDOWAndStops(@PathParam("tenantId") long tenantId,
+                                                      @QueryParam("dow")DayOfWeek day,
+                                                      @QueryParam("offset") int offset,
+                                                      @QueryParam("limit") int limit,
+                                                      @QueryParam("origin")String origin,
+                                                      @QueryParam("destination")String destination){
+
+        List<Service> serviceList = ejb.getServicesByTenantDOWAndStops(tenantId, day, origin, destination, offset, limit);
+        if (serviceList == null || origin.equals(destination)){
             return Response.status(Response.Status.NO_CONTENT).build();
         }
         return Response.ok(serviceList).build();


### PR DESCRIPTION
- Nuevo Endpoint que dado un DayOfWeek, tenantId, origin y destination,
  devuelve los servicios de ese DOW, y donde origin y destination forman
  parte de la ruta (no necesariamente extremos de la ruta), en ese orden.
  Ejemplo de llamada:

/rest/api/2/service/get/dowfromto?dow=FRIDAY&offset=0&limit=10&origin=Montevideo&destination=Colonia
- Cambio en path de endpoints de Services, ya que al haber varios GETs
  se tenían que diferenciar las rutas de alguna forma (perdón si no es la forma correcta).
